### PR TITLE
Disable trigger for Defensive stance

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -144,8 +144,8 @@ local function OnEvent(self, event)
 	if(GetSpellInfo(NAME_OVERPOWER)) then -- only load if player knows the spell
 		arr[1], arr[2], arr[3], arr[4],arr[5],arr[6],arr[7],arr[8],arr[9],arr[10],arr[11],arr[12],arr[13],arr[14],arr[15],arr[16],arr[17],arr[18],arr[19],arr[20] = CombatLogGetCurrentEventInfo() 
 		
-		-- read thru players combat log
-		if arr[5] == UnitName("player") then
+		-- read thru players combat log, check that the stance is not Defensive
+		if (arr[5] == UnitName("player") and GetShapeshiftForm() ~= 2) then
 			
 			
 			


### PR DESCRIPTION
MOA is useful in Battle and Berserker stances, but very annoying and useless in Defensive stance.
Tank will not switch to Battle stance to Overpower.
This small change will disable Alert when Defensive stance is detected.